### PR TITLE
Validate checkshum for downloaded files excluding git files

### DIFF
--- a/core/resolver.go
+++ b/core/resolver.go
@@ -229,7 +229,7 @@ func MoveSource(recipe *Recipe, source Source) error {
 // checksumValidation validates the checksum of a file
 func checksumValidation(source Source, path string) error {
 	//No checksum provided
-	if source.Checksum == "" {
+	if len(strings.TrimSpace(source.Checksum)) == 0 {
 		return nil
 	}
 	//open and read the Readme.md file
@@ -245,9 +245,6 @@ func checksumValidation(source Source, path string) error {
 		return fmt.Errorf("could not calculate tar file checksum")
 	}
 
-	fmt.Printf("%x", checksum.Sum(nil))
-	//Compare the checksums
-	fmt.Printf("%x", checksum.Sum(nil))
 	if fmt.Sprintf("%x", checksum.Sum(nil)) != source.Checksum {
 
 		return fmt.Errorf("tar file checksum doesn't match")

--- a/core/resolver.go
+++ b/core/resolver.go
@@ -232,11 +232,12 @@ func checksumValidation(source Source, path string) error {
 	if len(strings.TrimSpace(source.Checksum)) == 0 {
 		return nil
 	}
-	//open and read the Readme.md file
+	//Open the file
 	file, err := os.Open(path)
 	if err != nil {
 		return err
 	}
+	//Close the file when the function ends
 	defer file.Close()
 	//Calculate the checksum
 	checksum := sha256.New()
@@ -245,6 +246,7 @@ func checksumValidation(source Source, path string) error {
 		return fmt.Errorf("could not calculate tar file checksum")
 	}
 
+	//Validate the checksum
 	if fmt.Sprintf("%x", checksum.Sum(nil)) != source.Checksum {
 
 		return fmt.Errorf("tar file checksum doesn't match")

--- a/core/resolver.go
+++ b/core/resolver.go
@@ -1,6 +1,7 @@
 package core
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net/http"
@@ -176,15 +177,15 @@ func DownloadTarSource(recipe *Recipe, source Source) error {
 	}
 	//Check the tar file checksum
 	if source.Checksum != "" {
-		cmd := exec.Command(
-			"sha256sum", dest,
-		)
-		checksum, err := cmd.Output()
+		checksum := sha256.New()
+		//Calculate the checksum
+		_, err = io.Copy(checksum, res.Body)
 		if err != nil {
-			return err
+			return fmt.Errorf("could not calculate tar file checksum")
 		}
+
 		//Compare the checksums
-		if strings.Split(string(checksum), " ")[0] != source.Checksum {
+		if string(checksum.Sum(nil)) != source.Checksum {
 			return fmt.Errorf("tar file checksum doesn't match")
 		}
 

--- a/core/resolver_test.go
+++ b/core/resolver_test.go
@@ -1,0 +1,56 @@
+package core_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/vanilla-os/vib/core"
+)
+
+func TestDownloadSource(t *testing.T) {
+	recipe := &core.Recipe{
+		DownloadsPath: "/tmp/",
+	}
+	source := core.Source{
+		Type:     "tar",
+		URL:      "https://github.com/Vanilla-OS/Vib/archive/refs/tags/v0.3.1.tar.gz",
+		Module:   "example",
+		Checksum: "d28ab888c7b30fd1cc01e0a581169ea52dfb5bfcefaca721497f82734b6a5a98",
+	}
+	err := core.DownloadSource(recipe, source)
+	if err != nil {
+		t.Errorf("DownloadSource returned an error: %v", err)
+	}
+
+	// Check if the file was downloaded
+	dest := filepath.Join(recipe.DownloadsPath, source.Module)
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		t.Errorf("Downloaded file does not exist: %v", err)
+	}
+	defer os.Remove("/tmp/example") // clean up
+}
+
+func TestDownloadTarSource(t *testing.T) {
+	recipe := &core.Recipe{
+		DownloadsPath: "/tmp/",
+	}
+	source := core.Source{
+		Type:     "tar",
+		URL:      "https://github.com/Vanilla-OS/Vib/archive/refs/tags/v0.3.1.tar.gz",
+		Module:   "example",
+		Checksum: "d28ab888c7b30fd1cc01e0a581169ea52dfb5bfcefaca721497f82734b6a5a98",
+	}
+	err := core.DownloadTarSource(recipe, source)
+	if err != nil {
+		t.Errorf("DownloadTarSource returned an error: %v", err)
+	}
+
+	// Check if the file was downloaded
+	dest := filepath.Join(recipe.DownloadsPath, source.Module)
+	if _, err := os.Stat(dest); os.IsNotExist(err) {
+		t.Errorf("Downloaded file does not exist: %v", err)
+	}
+	defer os.Remove("/tmp/example") // clean up
+
+}

--- a/core/structs.go
+++ b/core/structs.go
@@ -32,6 +32,7 @@ type Module struct {
 
 type Source struct {
 	URL      string   `json:"url"`
+	Checksum string   `json:"checksum"`
 	Type     string   `json:"type"`
 	Commit   string   `json:"commit"`
 	Tag      string   `json:"tag"`


### PR DESCRIPTION
Modified the Source struct by adding a new field named Checksum of type string. This field will be validated using the sha256sum algorithm, provided it exists in the Source struct. If the checksum does not match, the DownloadTarSource function will now return an error.