### PR TITLE
fix: included modules not being included in the final recipe

### DIFF
--- a/core/loader.go
+++ b/core/loader.go
@@ -107,7 +107,7 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 		}
 	}
 
-	for _, stage := range recipe.Stages {
+	for i, stage := range recipe.Stages {
 		// here we check if the extra Adds path exists
 		for src := range stage.Adds {
 			fullPath := filepath.Join(filepath.Dir(recipePath), src)
@@ -153,6 +153,7 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 					} else if followsGhPattern(include) {
 						// if the include follows the github pattern, we need to
 						// download the recipe from the github repository
+						fmt.Printf("Downloading recipe from %s\n", include)
 						modulePath, err = downloadGhRecipe(include)
 						if err != nil {
 							return nil, err
@@ -176,6 +177,7 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 		}
 
 		stage.Modules = newRecipeModules
+		recipe.Stages[i] = stage
 	}
 
 	return recipe, nil


### PR DESCRIPTION
This is the Containerfile using our in repo example:

```dockerfile
# Stage: build
FROM debian:sid-slim AS build
LABEL maintainer='Vanilla OS Contributors'
ARG DEBIAN_FRONTEND=noninteractive
RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
ADD includes.container /
ADD sources /sources
RUN apt-get update
RUN apt install -y  libbtrfs-dev golang-go  && apt clean && cd /sources/abroot-git && go build -o /usr/local/bin/abroot
RUN apt install -y  xterm && apt clean
RUN apt install -y  wget curl  && apt clean
RUN apt install -y  nano vim  && apt clean
RUN mv /sources/man/man1/abroot.1 /usr/share/man/man1/ && apt install -y podman golang-github-containers-common patch wget && mkdir -p /usr/bin && cp /sources/abrootv2 /usr/bin/abroot && chmod +x /usr/bin/abroot && dpkg-divert --add --rename --divert /usr/bin/crun.original /usr/bin/crun && wget https://github.com/containers/crun/releases/download/1.14.4/crun-1.14.4-linux-amd64 -O /usr/bin/crun && chmod +x /usr/bin/crun
RUN mkdir -p /usr/share/apx && cp -r /sources/distrobox-1.7.0.1 /usr/share/apx/distrobox && chmod +x /usr/share/apx/distrobox/distrobox* && sed -E -i 's/.*printf "distrobox.*/echo apx \$(echo ${container_name} | sed "s|apx-||") enter/g' /usr/share/apx/distrobox/distrobox-create && mv /sources/man/man1/apx.1 /usr/share/man/man1/ && mkdir -p /usr/bin && cp /sources/apx /usr/bin/apx && chmod +x /usr/bin/apx
# Stage: test
FROM debian:sid-slim AS test
COPY --from=build /usr/local/bin/abroot /usr/local/bin/abroot
LABEL maintainer='Vanilla OS Contributors'
ARG DEBIAN_FRONTEND=noninteractive
RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
ADD includes.container /
ADD sources /sources
RUN ls -l /usr/local/bin/abroot
```