### PR TITLE
docs: fix incorrect Node example

### DIFF
--- a/docs/website/src/examples.hbs
+++ b/docs/website/src/examples.hbs
@@ -25,37 +25,31 @@
       </p>
       <div class="bg-gray-800 px-6 rounded-lg shadow-lg glass-effect overflow-x-auto">
         <pre class="text-xl text-gray-300"><code class="language-yaml">name: my-recipe
+id: my-node-app
 stages:
   - id: build
-    base: debian:sid-slim
+    base: node:current-slim
     labels:
       maintainer: My Awesome Team
     args:
       DEBIAN_FRONTEND: noninteractive
+    expose: 3000
+    entrypoint: ["node", "/app/app.js"]
     runs:
-      - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
+	- echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
     modules:
-    - name: update
-        type: shell
-        commands:
-        - apt update
-        
-    - name: vib
-      type: go
-      source:
-        type: git
-        url: https://github.com/vanilla-os/vib
-        branch: main
-        commit: latest
-      buildVars:
-        GO_OUTPUT_BIN: /usr/bin/vib
-      modules:
-        - name: golang
-          type: apt
-          source:
-          packages:
-            - golang
-            - ca-certificates
+	- name: build-app
+	  type: shell
+	  source:
+	    type: git
+	    url: https://github.com/mirkobrombin/node-sample
+	    branch: main
+	    commit: latest
+	  commands:
+	    - mv /sources/build-app /app
+	    - cd /app
+	    - npm i
+	    - npm run build
       </code></pre>
       </div>
       <p class="text-xl text-white mt-6">
@@ -79,6 +73,7 @@ stages:
         to use Vib.</p>
       <div class="bg-gray-800 px-6 rounded-lg shadow-lg glass-effect overflow-x-auto">
         <pre class="text-xl text-gray-300"><code class="language-yaml">name: my-recipe
+id: my-go-app
 stages:
   - id: build
     base: debian:sid-slim


### PR DESCRIPTION
Currently, both the examples on the website are the same (i.e. https://vib.vanillaos.org/examples) which was brought to my notice by someone on Discord, fixed the Node application example by going through the Git commit history and porting it to the newer Vib format.