### PR TITLE
fix[closes #36]: Use exec format for entrypoint

### DIFF
--- a/core/build.go
+++ b/core/build.go
@@ -226,7 +226,7 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		// ENTRYPOINT
 		if len(stage.Entrypoint) > 0 {
 			_, err = containerfile.WriteString(
-				fmt.Sprintf("ENTRYPOINT %s\n", strings.Join(stage.Entrypoint, " ")),
+				fmt.Sprintf("ENTRYPOINT [\"%s\"]\n", strings.Join(stage.Entrypoint, "\",\"")),
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
Uses the exec format for entrypoint as defined in https://docs.docker.com/reference/dockerfile/#entrypoint

Closes #36 