### PR TITLE
feat[closes #37]: Use exec format for cmd

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -34,7 +34,7 @@ type Stage struct {
 	Args        map[string]string `json:"args"`
 	Runs        []string          `json:"runs"`
 	Expose      map[string]string `json:"expose"`
-	Cmd         string            `json:"cmd"`
+	Cmd         []string          `json:"cmd"`
 	Modules     []interface{}     `json:"modules"`
 	Entrypoint  []string
 }

--- a/core/build.go
+++ b/core/build.go
@@ -214,9 +214,9 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// CMD
-		if stage.Cmd != "" {
+		if len(stage.Cmd) > 0 {
 			_, err = containerfile.WriteString(
-				fmt.Sprintf("CMD %s\n", stage.Cmd),
+				fmt.Sprintf("CMD [\"%s\"]\n", strings.Join(stage.Cmd, "\",\"")),
 			)
 			if err != nil {
 				return err

--- a/go.mod
+++ b/go.mod
@@ -18,3 +18,5 @@ require (
 	github.com/vanilla-os/vib/api v0.0.0-20240331150207-852011e4d96f
 	gopkg.in/yaml.v3 v3.0.1
 )
+
+replace github.com/vanilla-os/vib/api => ./api


### PR DESCRIPTION
Uses the exec format for `cmd` as defined in https://docs.docker.com/reference/dockerfile/#cmd

This is a breaking change for any recipe that uses the `cmd` field.

closes #37 