### PR TITLE
feat[close #45]: Add source destination option and split up sources

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -1,14 +1,15 @@
 package api
 
 type Source struct {
-	URL      string   `json:"url"`
-	Checksum string   `json:"checksum"`
-	Type     string   `json:"type"`
-	Commit   string   `json:"commit"`
-	Tag      string   `json:"tag"`
-	Branch   string   `json:"branch"`
-	Packages []string `json:"packages"`
-	Paths    []string `json:"paths"`
+	URL         string   `json:"url"`
+	Checksum    string   `json:"checksum"`
+	Type        string   `json:"type"`
+	Destination string   `json:"destination"`
+	Commit      string   `json:"commit"`
+	Tag         string   `json:"tag"`
+	Branch      string   `json:"branch"`
+	Packages    []string `json:"packages"`
+	Paths       []string `json:"paths"`
 }
 
 type Recipe struct {

--- a/core/apt.go
+++ b/core/apt.go
@@ -92,3 +92,4 @@ func BuildAptModule(moduleInterface interface{}, recipe *api.Recipe) (string, er
 
 	return "", errors.New("no packages or paths specified")
 }
+

--- a/core/cmake.go
+++ b/core/cmake.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 
@@ -43,7 +44,7 @@ func BuildCMakeModule(moduleInterface interface{}, recipe *api.Recipe) (string, 
 
 	cmd := fmt.Sprintf(
 		"cd /sources/%s && mkdir -p build && cd build && cmake ..%s && make",
-		module.Name,
+		filepath.Join(recipe.SourcesPath, api.GetSourcePath(module.Source, module.Name)),
 		buildFlags,
 	)
 

--- a/core/dpkg-buildpackage.go
+++ b/core/dpkg-buildpackage.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/vanilla-os/vib/api"
@@ -33,7 +34,7 @@ func BuildDpkgBuildPkgModule(moduleInterface interface{}, recipe *api.Recipe) (s
 
 	cmd := fmt.Sprintf(
 		"cd /sources/%s && dpkg-buildpackage -d -us -uc -b",
-		module.Name,
+		filepath.Join(api.GetSourcePath(module.Source, module.Name)),
 	)
 
 	for _, path := range module.Source.Paths {

--- a/core/dpkg.go
+++ b/core/dpkg.go
@@ -30,7 +30,7 @@ func BuildDpkgModule(moduleInterface interface{}, recipe *api.Recipe) (string, e
 	}
 	cmd := ""
 	for _, path := range module.Source.Paths {
-		cmd += fmt.Sprintf(" dpkg -i /sources/%s && apt install -f && ", path)
+		cmd += fmt.Sprintf(" dpkg -i /sources/%s/%s && apt install -f && ", module.Name, path)
 	}
 
 	cmd += " && apt clean"

--- a/core/go.go
+++ b/core/go.go
@@ -50,7 +50,7 @@ func BuildGoModule(moduleInterface interface{}, recipe *api.Recipe) (string, err
 
 	cmd := fmt.Sprintf(
 		"cd /sources/%s && go build%s -o %s",
-		module.Name,
+		api.GetSourcePath(module.Source, module.Name),
 		buildFlags,
 		buildVars["GO_OUTPUT_BIN"],
 	)

--- a/core/make.go
+++ b/core/make.go
@@ -27,5 +27,5 @@ func BuildMakeModule(moduleInterface interface{}, recipe *api.Recipe) (string, e
 		return "", err
 	}
 
-	return "cd /sources/" + module.Name + " && make && make install", nil
+	return "cd /sources/" + api.GetSourcePath(module.Source, module.Name) + " && make && make install", nil
 }

--- a/core/meson.go
+++ b/core/meson.go
@@ -34,7 +34,7 @@ func BuildMesonModule(moduleInterface interface{}, recipe *api.Recipe) (string, 
 	tmpDir := fmt.Sprintf("/tmp/%s-%s", module.Source.Checksum, module.Name)
 	cmd := fmt.Sprintf(
 		"cd /sources/%s && meson %s && ninja -C %s && ninja -C %s install",
-		module.Name,
+		api.GetSourcePath(module.Source, module.Name),
 		tmpDir,
 		tmpDir,
 		tmpDir,


### PR DESCRIPTION
This makes vib download any sources into a subdirectory for every module and adds the option to download files into an extra subdirectory to allow easier seperation of sources.

Closes #45