### PR TITLE
feat[closes #50]: Use apt-get instead of apt

### DIFF
--- a/core/apt.go
+++ b/core/apt.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 
 	"github.com/mitchellh/mapstructure"
+
 	"github.com/vanilla-os/vib/api"
 )
 
@@ -54,7 +55,7 @@ func BuildAptModule(moduleInterface interface{}, recipe *api.Recipe) (string, er
 			packages += pkg + " "
 		}
 
-		return fmt.Sprintf("apt install -y %s %s && apt clean", args, packages), nil
+		return fmt.Sprintf("apt-get install -y %s %s && apt-get clean", args, packages), nil
 	}
 
 	if len(module.Source.Paths) > 0 {
@@ -92,4 +93,3 @@ func BuildAptModule(moduleInterface interface{}, recipe *api.Recipe) (string, er
 
 	return "", errors.New("no packages or paths specified")
 }
-


### PR DESCRIPTION
# Use apt-get instead of apt

Closes #50 

## Description

`apt` is the recommended command for interactive use by administrators, not for use in shell scripts. Furthermore, the current use of `apt` is causing CLI warnings:

>  apt does not have a stable CLI interface. Use with caution in scripts.

This PR updates the apt core package to use `apt-get *` command variants for all apt commands (install and clean) 

### Proposed Changes

- Use `apt-get install` instead of `apt install`
- Use `apt-get clean` instead of `apt clean`
- Some formatting changes (via https://github.com/incu6us/goimports-reviser)

### Local Testing

Using the following `vib.yml` recipe:

```yml
name: my-recipe
id: my-test
stages:
  - id: build
    base: debian:sid-slim
    labels:
      maintainer: My Awesome Team
    args:
      DEBIAN_FRONTEND: noninteractive
    runs:
      - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
    modules:
      - name: update
        type: shell
        commands:
          - apt-get update
      - name: example-packages # Sample module using the built-in Apt module to install packages
        type: apt
        source:
          packages:
            - vim
```

```sh
vib build vim.yml
```

![image](https://github.com/Vanilla-OS/Vib/assets/47409392/1d3f0894-ed35-43f8-9461-5747d706cc65)

Generated Containerfile:

```dockerfile
# Stage: build
FROM debian:sid-slim AS build
LABEL maintainer='My Awesome Team'
ARG DEBIAN_FRONTEND=noninteractive
RUN echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
ADD includes.container /
ADD sources /sources
RUN apt-get update
RUN apt-get install -y  vim  && apt-get clean

```
