### PR TITLE
feat[closes #38]: add workdir instruction support

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -32,7 +32,7 @@ type Stage struct {
 	Copy        []Copy            `json:"copy"`
 	Labels      map[string]string `json:"labels"`
 	Env         map[string]string `json:"env"`
-	Adds        Add               `json:"adds"`
+	Adds        []Add             `json:"adds"`
 	Args        map[string]string `json:"args"`
 	Runs        Run               `json:"runs"`
 	Expose      map[string]string `json:"expose"`

--- a/api/structs.go
+++ b/api/structs.go
@@ -15,6 +15,7 @@ type Source struct {
 type Recipe struct {
 	Name          string
 	Id            string
+	Cwd           string
 	Stages        []Stage
 	Path          string
 	ParentPath    string
@@ -50,12 +51,7 @@ type Path struct {
 	Dst string
 }
 
-type Workdir struct {
-	Path    string
-	Restore bool
-}
-
 type Entrypoint struct {
-	Exec []string
-	Cwd  Workdir
+	Exec    []string
+	Workdir string
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -36,7 +36,7 @@ type Stage struct {
 	Args        map[string]string `json:"args"`
 	Runs        Run               `json:"runs"`
 	Expose      map[string]string `json:"expose"`
-	Cmd         []string          `json:"cmd"`
+	Cmd         Cmd               `json:"cmd"`
 	Modules     []interface{}     `json:"modules"`
 	Entrypoint  Entrypoint
 }
@@ -53,6 +53,11 @@ type Path struct {
 }
 
 type Entrypoint struct {
+	Exec    []string
+	Workdir string
+}
+
+type Cmd struct {
 	Exec    []string
 	Workdir string
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -15,7 +15,6 @@ type Source struct {
 type Recipe struct {
 	Name          string
 	Id            string
-	Cwd           string
 	Stages        []Stage
 	Path          string
 	ParentPath    string

--- a/api/structs.go
+++ b/api/structs.go
@@ -34,7 +34,7 @@ type Stage struct {
 	Env         map[string]string `json:"env"`
 	Adds        map[string]string `json:"adds"`
 	Args        map[string]string `json:"args"`
-	Runs        []string          `json:"runs"`
+	Runs        Run               `json:"runs"`
 	Expose      map[string]string `json:"expose"`
 	Cmd         []string          `json:"cmd"`
 	Modules     []interface{}     `json:"modules"`
@@ -54,5 +54,10 @@ type Path struct {
 
 type Entrypoint struct {
 	Exec    []string
+	Workdir string
+}
+
+type Run struct {
+	Shell   []string
 	Workdir string
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -58,6 +58,6 @@ type Entrypoint struct {
 }
 
 type Run struct {
-	Shell   []string
-	Workdir string
+	Commands []string
+	Workdir  string
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -37,7 +37,7 @@ type Stage struct {
 	Expose      map[string]string `json:"expose"`
 	Cmd         []string          `json:"cmd"`
 	Modules     []interface{}     `json:"modules"`
-	Entrypoint  []string
+	Entrypoint  Entrypoint
 }
 
 type Copy struct {
@@ -48,4 +48,14 @@ type Copy struct {
 type Path struct {
 	Src string
 	Dst string
+}
+
+type Workdir struct {
+	Path    string
+	Restore bool
+}
+
+type Entrypoint struct {
+	Exec []string
+	Cwd  Workdir
 }

--- a/api/structs.go
+++ b/api/structs.go
@@ -42,8 +42,9 @@ type Stage struct {
 }
 
 type Copy struct {
-	From  string
-	Paths []Path
+	From    string
+	Paths   []Path
+	Workdir string
 }
 
 type Path struct {

--- a/api/structs.go
+++ b/api/structs.go
@@ -32,7 +32,7 @@ type Stage struct {
 	Copy        []Copy            `json:"copy"`
 	Labels      map[string]string `json:"labels"`
 	Env         map[string]string `json:"env"`
-	Adds        map[string]string `json:"adds"`
+	Adds        Add               `json:"adds"`
 	Args        map[string]string `json:"args"`
 	Runs        Run               `json:"runs"`
 	Expose      map[string]string `json:"expose"`
@@ -50,6 +50,11 @@ type Copy struct {
 type Path struct {
 	Src string
 	Dst string
+}
+
+type Add struct {
+	SrcDst  map[string]string
+	Workdir string
 }
 
 type Entrypoint struct {

--- a/core/build.go
+++ b/core/build.go
@@ -92,6 +92,23 @@ func BuildContainerfile(recipe *api.Recipe) error {
 						return err
 					}
 				}
+				for _, path := range copy.Paths {
+					if copy.From != "" {
+						_, err = containerfile.WriteString(
+							fmt.Sprintf("COPY --from=%s %s %s\n", copy.From, path.Src, path.Dst),
+						)
+						if err != nil {
+							return err
+						}
+					} else {
+						_, err = containerfile.WriteString(
+							fmt.Sprintf("COPY %s %s\n", path.Src, path.Dst),
+						)
+						if err != nil {
+							return err
+						}
+					}
+				}
 			}
 		}
 

--- a/core/build.go
+++ b/core/build.go
@@ -83,29 +83,31 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		// COPY
 		if len(stage.Copy) > 0 {
 			for _, copy := range stage.Copy {
-				if copy.Workdir != "" && copy.Workdir != recipe.Cwd {
-					_, err = containerfile.WriteString(
-						fmt.Sprintf("WORKDIR %s\n", copy.Workdir),
-					)
-					recipe.Cwd = copy.Workdir
-					if err != nil {
-						return err
-					}
-				}
-				for _, path := range copy.Paths {
-					if copy.From != "" {
+				if len(copy.Paths) > 0 {
+					if copy.Workdir != "" && copy.Workdir != recipe.Cwd {
 						_, err = containerfile.WriteString(
-							fmt.Sprintf("COPY --from=%s %s %s\n", copy.From, path.Src, path.Dst),
+							fmt.Sprintf("WORKDIR %s\n", copy.Workdir),
 						)
+						recipe.Cwd = copy.Workdir
 						if err != nil {
 							return err
 						}
-					} else {
-						_, err = containerfile.WriteString(
-							fmt.Sprintf("COPY %s %s\n", path.Src, path.Dst),
-						)
-						if err != nil {
-							return err
+					}
+					for _, path := range copy.Paths {
+						if copy.From != "" {
+							_, err = containerfile.WriteString(
+								fmt.Sprintf("COPY --from=%s %s %s\n", copy.From, path.Src, path.Dst),
+							)
+							if err != nil {
+								return err
+							}
+						} else {
+							_, err = containerfile.WriteString(
+								fmt.Sprintf("COPY %s %s\n", path.Src, path.Dst),
+							)
+							if err != nil {
+								return err
+							}
 						}
 					}
 				}

--- a/core/build.go
+++ b/core/build.go
@@ -179,7 +179,16 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// ADDS
-		for key, value := range stage.Adds {
+		if stage.Adds.Workdir != "" && stage.Adds.Workdir != recipe.Cwd {
+			_, err = containerfile.WriteString(
+				fmt.Sprintf("WORKDIR %s\n", stage.Adds.Workdir),
+			)
+			recipe.Cwd = stage.Adds.Workdir
+			if err != nil {
+				return err
+			}
+		}
+		for key, value := range stage.Adds.SrcDst {
 			_, err = containerfile.WriteString(
 				fmt.Sprintf("ADD %s %s\n", key, value),
 			)

--- a/core/build.go
+++ b/core/build.go
@@ -85,11 +85,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		if len(stage.Copy) > 0 {
 			for _, copy := range stage.Copy {
 				if len(copy.Paths) > 0 {
-					if copy.Workdir != "" && copy.Workdir != recipe.Cwd {
+					if copy.Workdir != "" {
 						_, err = containerfile.WriteString(
 							fmt.Sprintf("WORKDIR %s\n", copy.Workdir),
 						)
-						recipe.Cwd = copy.Workdir
 						if err != nil {
 							return err
 						}
@@ -148,11 +147,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		// RUN(S)
 		if !stage.SingleLayer {
 			if len(stage.Runs.Commands) > 0 {
-				if stage.Runs.Workdir != "" && stage.Runs.Workdir != recipe.Cwd {
+				if stage.Runs.Workdir != "" {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("WORKDIR %s\n", stage.Runs.Workdir),
 					)
-					recipe.Cwd = stage.Runs.Workdir
 					if err != nil {
 						return err
 					}
@@ -182,11 +180,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		if len(stage.Adds) > 0 {
 			for _, add := range stage.Adds {
 				if len(add.SrcDst) > 0 {
-					if add.Workdir != "" && add.Workdir != recipe.Cwd {
+					if add.Workdir != "" {
 						_, err = containerfile.WriteString(
 							fmt.Sprintf("WORKDIR %s\n", add.Workdir),
 						)
-						recipe.Cwd = add.Workdir
 						if err != nil {
 							return err
 						}
@@ -222,11 +219,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 					continue
 				}
 
-				if cmd.Workdir != "" && cmd.Workdir != recipe.Cwd {
+				if cmd.Workdir != "" {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("WORKDIR %s\n", cmd.Workdir),
 					)
-					recipe.Cwd = cmd.Workdir
 					if err != nil {
 						return err
 					}
@@ -244,11 +240,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		// SINGLE LAYER
 		if stage.SingleLayer {
 			if len(stage.Runs.Commands) > 0 {
-				if stage.Runs.Workdir != "" && stage.Runs.Workdir != recipe.Cwd {
+				if stage.Runs.Workdir != "" {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("WORKDIR %s\n", stage.Runs.Workdir),
 					)
-					recipe.Cwd = stage.Runs.Workdir
 					if err != nil {
 						return err
 					}
@@ -287,11 +282,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// CMD
-		if stage.Cmd.Workdir != "" && stage.Cmd.Workdir != recipe.Cwd {
+		if stage.Cmd.Workdir != "" {
 			_, err = containerfile.WriteString(
 				fmt.Sprintf("WORKDIR %s\n", stage.Cmd.Workdir),
 			)
-			recipe.Cwd = stage.Cmd.Workdir
 			if err != nil {
 				return err
 			}
@@ -306,11 +300,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// ENTRYPOINT
-		if stage.Entrypoint.Workdir != "" && stage.Entrypoint.Workdir != recipe.Cwd {
+		if stage.Entrypoint.Workdir != "" {
 			_, err = containerfile.WriteString(
 				fmt.Sprintf("WORKDIR %s\n", stage.Entrypoint.Workdir),
 			)
-			recipe.Cwd = stage.Entrypoint.Workdir
 			if err != nil {
 				return err
 			}

--- a/core/build.go
+++ b/core/build.go
@@ -272,9 +272,18 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// CMD
-		if len(stage.Cmd) > 0 {
+		if stage.Cmd.Workdir != "" && stage.Cmd.Workdir != recipe.Cwd {
 			_, err = containerfile.WriteString(
-				fmt.Sprintf("CMD [\"%s\"]\n", strings.Join(stage.Cmd, "\",\"")),
+				fmt.Sprintf("WORKDIR %s\n", stage.Cmd.Workdir),
+			)
+			recipe.Cwd = stage.Cmd.Workdir
+			if err != nil {
+				return err
+			}
+		}
+		if len(stage.Cmd.Exec) > 0 {
+			_, err = containerfile.WriteString(
+				fmt.Sprintf("CMD [\"%s\"]\n", strings.Join(stage.Cmd.Exec, "\",\"")),
 			)
 			if err != nil {
 				return err

--- a/core/build.go
+++ b/core/build.go
@@ -83,10 +83,11 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		// COPY
 		if len(stage.Copy) > 0 {
 			for _, copy := range stage.Copy {
-				for _, path := range copy.Paths {
+				if copy.Workdir != "" && copy.Workdir != recipe.Cwd {
 					_, err = containerfile.WriteString(
-						fmt.Sprintf("COPY --from=%s %s %s\n", copy.From, path.Src, path.Dst),
+						fmt.Sprintf("WORKDIR %s\n", copy.Workdir),
 					)
+					recipe.Cwd = copy.Workdir
 					if err != nil {
 						return err
 					}

--- a/core/build.go
+++ b/core/build.go
@@ -225,10 +225,11 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// ENTRYPOINT
-		if stage.Entrypoint.Cwd.Path != "" {
+		if stage.Entrypoint.Workdir != "" && stage.Entrypoint.Workdir != recipe.Cwd {
 			_, err = containerfile.WriteString(
-				fmt.Sprintf("WORKDIR %s\n", stage.Entrypoint.Cwd.Path),
+				fmt.Sprintf("WORKDIR %s\n", stage.Entrypoint.Workdir),
 			)
+			recipe.Cwd = stage.Entrypoint.Workdir
 			if err != nil {
 				return err
 			}
@@ -236,14 +237,6 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		if len(stage.Entrypoint.Exec) > 0 {
 			_, err = containerfile.WriteString(
 				fmt.Sprintf("ENTRYPOINT [\"%s\"]\n", strings.Join(stage.Entrypoint.Exec, "\",\"")),
-			)
-			if err != nil {
-				return err
-			}
-		}
-		if stage.Entrypoint.Cwd.Restore {
-			_, err = containerfile.WriteString(
-				fmt.Sprintf("WORKDIR %s\n", "/"),
 			)
 			if err != nil {
 				return err

--- a/core/build.go
+++ b/core/build.go
@@ -147,7 +147,7 @@ func BuildContainerfile(recipe *api.Recipe) error {
 
 		// RUN(S)
 		if !stage.SingleLayer {
-			if len(stage.Runs.Shell) > 0 {
+			if len(stage.Runs.Commands) > 0 {
 				if stage.Runs.Workdir != "" && stage.Runs.Workdir != recipe.Cwd {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("WORKDIR %s\n", stage.Runs.Workdir),
@@ -157,7 +157,7 @@ func BuildContainerfile(recipe *api.Recipe) error {
 						return err
 					}
 				}
-				for _, cmd := range stage.Runs.Shell {
+				for _, cmd := range stage.Runs.Commands {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("RUN %s\n", cmd),
 					)
@@ -228,7 +228,7 @@ func BuildContainerfile(recipe *api.Recipe) error {
 
 		// SINGLE LAYER
 		if stage.SingleLayer {
-			if len(stage.Runs.Shell) > 0 {
+			if len(stage.Runs.Commands) > 0 {
 				if stage.Runs.Workdir != "" && stage.Runs.Workdir != recipe.Cwd {
 					_, err = containerfile.WriteString(
 						fmt.Sprintf("WORKDIR %s\n", stage.Runs.Workdir),
@@ -241,9 +241,9 @@ func BuildContainerfile(recipe *api.Recipe) error {
 
 				unifiedCmd := "RUN "
 
-				for i, cmd := range stage.Runs.Shell {
+				for i, cmd := range stage.Runs.Commands {
 					unifiedCmd += cmd
-					if i != len(stage.Runs.Shell)-1 {
+					if i != len(stage.Runs.Commands)-1 {
 						unifiedCmd += " && "
 					}
 				}

--- a/core/build.go
+++ b/core/build.go
@@ -179,21 +179,27 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// ADDS
-		if stage.Adds.Workdir != "" && stage.Adds.Workdir != recipe.Cwd {
-			_, err = containerfile.WriteString(
-				fmt.Sprintf("WORKDIR %s\n", stage.Adds.Workdir),
-			)
-			recipe.Cwd = stage.Adds.Workdir
-			if err != nil {
-				return err
-			}
-		}
-		for key, value := range stage.Adds.SrcDst {
-			_, err = containerfile.WriteString(
-				fmt.Sprintf("ADD %s %s\n", key, value),
-			)
-			if err != nil {
-				return err
+		if len(stage.Adds) > 0 {
+			for _, add := range stage.Adds {
+				if len(add.SrcDst) > 0 {
+					if add.Workdir != "" && add.Workdir != recipe.Cwd {
+						_, err = containerfile.WriteString(
+							fmt.Sprintf("WORKDIR %s\n", add.Workdir),
+						)
+						recipe.Cwd = add.Workdir
+						if err != nil {
+							return err
+						}
+					}
+					for key, value := range add.SrcDst {
+						_, err = containerfile.WriteString(
+							fmt.Sprintf("ADD %s %s\n", key, value),
+						)
+						if err != nil {
+							return err
+						}
+					}
+				}
 			}
 		}
 

--- a/core/build.go
+++ b/core/build.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-
 	"github.com/vanilla-os/vib/api"
 )
 

--- a/core/build.go
+++ b/core/build.go
@@ -175,6 +175,16 @@ func BuildContainerfile(recipe *api.Recipe) error {
 					continue
 				}
 
+				if cmd.Workdir != "" && cmd.Workdir != recipe.Cwd {
+					_, err = containerfile.WriteString(
+						fmt.Sprintf("WORKDIR %s\n", cmd.Workdir),
+					)
+					recipe.Cwd = cmd.Workdir
+					if err != nil {
+						return err
+					}
+				}
+
 				_, err = containerfile.WriteString(
 					fmt.Sprintf("RUN %s\n", cmd.Command),
 				)
@@ -265,6 +275,7 @@ func BuildModules(recipe *api.Recipe, modules []interface{}) ([]ModuleCommand, e
 		cmds = append(cmds, ModuleCommand{
 			Name:    module.Name,
 			Command: cmd,
+			Workdir: module.Workdir,
 		})
 	}
 

--- a/core/loader.go
+++ b/core/loader.go
@@ -19,7 +19,7 @@ import (
 // Does not validate the recipe but it will catch some errors
 // a proper validation will be done in the future
 func LoadRecipe(path string) (*api.Recipe, error) {
-	recipe := &api.Recipe{Cwd: "/"}
+	recipe := &api.Recipe{}
 
 	// we use the absolute path to the recipe file as the
 	// root path for the recipe and all its files
@@ -94,7 +94,7 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 	// the includes directory is the place where we store all the
 	// files to be included in the container, this is useful for
 	// example to include configuration files. Each file must follow
-	// the File Hierachy Standard (FHS) and be placed in the correct
+	// the File Hierarchy Standard (FHS) and be placed in the correct
 	// directory. For example, if you want to include a file in
 	// /etc/nginx/nginx.conf you must place it in includes/etc/nginx/nginx.conf
 	// so it will be copied to the correct location in the container

--- a/core/loader.go
+++ b/core/loader.go
@@ -10,16 +10,16 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/vanilla-os/vib/api"
-
 	"gopkg.in/yaml.v3"
+
+	"github.com/vanilla-os/vib/api"
 )
 
 // LoadRecipe loads a recipe from a file and returns a Recipe
 // Does not validate the recipe but it will catch some errors
 // a proper validation will be done in the future
 func LoadRecipe(path string) (*api.Recipe, error) {
-	recipe := &api.Recipe{}
+	recipe := &api.Recipe{Cwd: "/"}
 
 	// we use the absolute path to the recipe file as the
 	// root path for the recipe and all its files

--- a/core/loader.go
+++ b/core/loader.go
@@ -109,11 +109,13 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 
 	for i, stage := range recipe.Stages {
 		// here we check if the extra Adds path exists
-		for src := range stage.Adds.SrcDst {
-			fullPath := filepath.Join(filepath.Dir(recipePath), src)
-			_, err = os.Stat(fullPath)
-			if os.IsNotExist(err) {
-				return nil, err
+		for _, add := range stage.Adds {
+			for src := range add.SrcDst {
+				fullPath := filepath.Join(filepath.Dir(recipePath), src)
+				_, err = os.Stat(fullPath)
+				if os.IsNotExist(err) {
+					return nil, err
+				}
 			}
 		}
 

--- a/core/loader.go
+++ b/core/loader.go
@@ -10,9 +10,8 @@ import (
 	"strings"
 
 	"github.com/mitchellh/mapstructure"
-	"gopkg.in/yaml.v3"
-
 	"github.com/vanilla-os/vib/api"
+	"gopkg.in/yaml.v3"
 )
 
 // LoadRecipe loads a recipe from a file and returns a Recipe

--- a/core/loader.go
+++ b/core/loader.go
@@ -109,7 +109,7 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 
 	for i, stage := range recipe.Stages {
 		// here we check if the extra Adds path exists
-		for src := range stage.Adds {
+		for src := range stage.Adds.SrcDst {
 			fullPath := filepath.Join(filepath.Dir(recipePath), src)
 			_, err = os.Stat(fullPath)
 			if os.IsNotExist(err) {

--- a/core/structs.go
+++ b/core/structs.go
@@ -4,9 +4,10 @@ import "C"
 
 type Module struct {
 	Name    string `json:"name"`
+	Workdir string
 	Type    string `json:"type"`
 	Modules []map[string]interface{}
-	Content []byte // The entire module unparsed as a []byte, used by plugins
+	Content []byte
 }
 
 type IncludesModule struct {
@@ -18,6 +19,7 @@ type IncludesModule struct {
 type ModuleCommand struct {
 	Name    string
 	Command string
+	Workdir string
 }
 
 type Plugin struct {

--- a/core/structs.go
+++ b/core/structs.go
@@ -7,7 +7,7 @@ type Module struct {
 	Workdir string
 	Type    string `json:"type"`
 	Modules []map[string]interface{}
-	Content []byte
+	Content []byte // The entire module unparsed as a []byte, used by plugins
 }
 
 type IncludesModule struct {


### PR DESCRIPTION
# Add `WORKDIR` instruction support

Closes #38

⚠️NOTE⚠️
---
- I am marking this PR as a draft since a lot of things require feedback from the upstream developers.
- The proposed changes introduce **breaking changes** as they alter the recipe structure meaning that existing recipes will no longer build without adopting the new style.
- I will be happy to do any necessary adjustments to be in line with the upstream developers' vision of this feature.
- The workdir related checks for each supported command are the same so maybe we can extract it to avoid duplicated code. I want to avoid refactoring/simplification until we come to an agreement of how this feature should be implemented.

## Description

This PR adds support for the [`WORKDIR`](https://docs.docker.com/reference/dockerfile/#workdir) instruction to various commands.  It also checks to ensure that unnecessary `WORKDIR` instructions are ignored when the requested working directory is already the present working directory by having a recipe level PWD. 

### Proposed Changes

- Add `WORKDIR` instruction support for all possible commands:
  - RUN, 
  - CMD
  - ENTRYPOINT 
  - COPY 
  - ADD  
- ~~Use a recipe wide PWD variable to keep track of the present working directory to avoid unnecessary (albeit harmless) instructions~~
- Restore working directory back to default path (/) after command execution
   -~~Always set the recipe's initial PWD to root (/) like default Docker~~
- Ensure that when using `singlelayer: true`  `WORKDIR` mismatches do not occur (not sure if the check is needed so TBD)
- Add support for standard COPY (not only per stage copy via --from)
- Add support for multiple adds (like copy) each with different workdir if needed
- Update recipe structure documentation
- Fix doc formatting with [prettier](https://github.com/prettier/prettier) and [mardownlint](https://github.com/DavidAnson/markdownlint)
- Fix formatting with [gofumpt](https://github.com/mvdan/gofumpt) and [goimportx](https://github.com/kesonan/goimportx)

### Local Testing

Using the following `vib.yml` recipe (based on the original [chronos-fe](https://images.vanillaos.org/#/recipe/chronos-fe) recipe):

```yml
name: Chronos Frontend Image
id: chronos-fe
stages:
  - id: build
    base: node:lts
    singlelayer: false
    labels:
      maintainer: Vanilla OS Contributors
    adds:
      - workdir: /tmp/user/files
        srcdst:
          go.mod: .
      - workdir: /tmp/otheruser/files
        srcdst:
          go.mod: .
          go.sum: .
    copy:
      - workdir: /tmp
        from: build
        paths:
          - src: /app/awesome.txt
            dst: .
          - src: /tmp/test.txt
            dst: .
      - workdir: /etc
        paths:
          - src: /app/hello.txt
            dst: .
    cmd:
      workdir: /app2
      exec:
        - python
        - prog.py
    entrypoint:
      workdir: /app
      exec:
        - npm
        - run
        - build
    runs:
      workdir: /etc/apt/apt.conf.d
      commands:
        - echo 'APT::Install-Recommends "1";' > 01norecommends
    expose:
      "6090": ""
    modules:
      - name: build-app
        type: shell
        workdir: /app
        source:
          type: git
          url: https://github.com/Vanilla-OS/chronos-frontend
          branch: main
          commit: latest
        commands:
          - mv /sources/build-app .
          - npm install
          - npm run build
repo: vanilla-os/chronos-frontend
```

```sh
vib build vim.yml
```
![image](https://github.com/Vanilla-OS/Vib/assets/47409392/d11d9d19-ef2c-42c7-bb30-7df884f2532d)


Generated Containerfile:

```dockerfile
# Stage: build
FROM node:lts AS build
WORKDIR /tmp
COPY --from=build /app/awesome.txt .
COPY --from=build /tmp/test.txt .
WORKDIR /
WORKDIR /etc
COPY /app/hello.txt .
WORKDIR /
LABEL maintainer='Vanilla OS Contributors'
WORKDIR /etc/apt/apt.conf.d
RUN echo 'APT::Install-Recommends "1";' > 01norecommends
WORKDIR /
EXPOSE 6090/
WORKDIR /tmp/user/files
ADD go.mod .
WORKDIR /
WORKDIR /tmp/otheruser/files
ADD go.mod .
ADD go.sum .
WORKDIR /
ADD includes.container /
ADD sources /sources
WORKDIR /app
RUN mv /sources/build-app . && npm install && npm run build
WORKDIR /
WORKDIR /app2
CMD ["python","prog.py"]
WORKDIR /
WORKDIR /app
ENTRYPOINT ["npm","run","build"]
WORKDIR /
```

