### PR TITLE
feat/59 cmd implement version flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "vib",
-	Short: "Vib is a tool to build container images from recipes using modules",
-	Long:  "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
+	Use:     "vib",
+	Short:   "Vib is a tool to build container images from recipes using modules",
+	Long:    "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
+	Version: "0.7.3",
 }
 
 func init() {


### PR DESCRIPTION
Closes #59 

Cobra Command struct comes with Version field. Once the version field is set, we have a version(-v or --version) flag. See attached screenshot.
![vib_version_flag](https://github.com/Vanilla-OS/Vib/assets/3803259/bdc0d473-7ba5-4e69-9468-5530ef948dff)
