### PR TITLE
feat/59 cmd implement version flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,9 +5,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "vib",
-	Short: "Vib is a tool to build container images from recipes using modules",
-	Long:  "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
+	Use:     "vib",
+	Short:   "Vib is a tool to build container images from recipes using modules",
+	Long:    "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
+	Version: "0.7.3",
 }
 
 func init() {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,11 +4,13 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var Version = "0.7.3"
+
 var rootCmd = &cobra.Command{
 	Use:     "vib",
 	Short:   "Vib is a tool to build container images from recipes using modules",
 	Long:    "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
-	Version: "0.7.3",
+	Version: Version,
 }
 
 func init() {

--- a/main.go
+++ b/main.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	Version = "0.6.2"
+	Version = cmd.Version
 )
 
 func main() {


### PR DESCRIPTION
Closes #59 

**Bug:** main has a different version number than cmd package. This leads to confusion and inconsistency.
**Fix:** Created a version variable in cmd package and set it to the latest version of vib. Then use the same variable in main too.