### PR TITLE
Fix installprefix not being set correctly during build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ all: build # plugins
 
 build:
 	mkdir -p build
-	sed 's|$$INSTALLPREFIX$$|${PREFIX}|g' core/plugins.in > core/plugins.go
+	sed 's|%INSTALLPREFIX%|${PREFIX}|g' core/plugins.in > core/plugins.go
 	go build -a -o build/${BINARY_NAME}
 
 build-plugins: FORCE

--- a/core/plugins.in
+++ b/core/plugins.in
@@ -26,7 +26,7 @@ func LoadPlugin(name string, module interface{}, recipe *api.Recipe) (string, er
 
 		localPluginPath := fmt.Sprintf("%s/%s.so", recipe.PluginPath, name)
 
-		globalPluginPath := fmt.Sprintf("$INSTALLPREFIX$/share/vib/plugins/%s.so", name)
+		globalPluginPath := fmt.Sprintf("%INSTALLPREFIX%/share/vib/plugins/%s.so", name)
 
 		// Prefer local plugins before global ones
 		var loadedPlugin uintptr


### PR DESCRIPTION
Resolves an issue where the `sed` command in the Makefile wouldn't set the install prefix in core/plugins.in correctly