### PR TITLE
fix: add missing commands to example

### DIFF
--- a/docs/articles/en/getting-started.md
+++ b/docs/articles/en/getting-started.md
@@ -69,7 +69,8 @@ stages:
     args:
       DEBIAN_FRONTEND: noninteractive
     runs:
-      - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
+      commands:
+        - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
     modules:
       - name: update
         type: shell

--- a/example/example.yml
+++ b/example/example.yml
@@ -9,7 +9,8 @@ stages:
     args:
       DEBIAN_FRONTEND: noninteractive
     runs:
-    - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
+      commands:
+        - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
 
     modules:
     - name: update-repo
@@ -56,7 +57,8 @@ stages:
     args:
       DEBIAN_FRONTEND: noninteractive
     runs:
-    - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
+      commands:
+        - echo 'APT::Install-Recommends "0";' > /etc/apt/apt.conf.d/01norecommends
     copy:
       - from: build
         paths:


### PR DESCRIPTION
The "Getting Started" example seems to be missing the `commands`  instruction under the `runs` section. As discussed in https://github.com/Vanilla-OS/Vib/issues/92, the installation instructions are also outdated, but updating the example felt like a quick win already, which will probably prevet other user to dig the documentaion like I had to. 