### PR TITLE
fix: update buildflags meson example

### DIFF
--- a/docs/articles/en/built-in-modules.md
+++ b/docs/articles/en/built-in-modules.md
@@ -205,7 +205,8 @@ The following specific fields are available:
 ```yaml
 - name: example-meson-project
   type: meson
-  buildflags: "-Dfoo=bar"
+  buildflags:
+  - "-Dfoo=bar"
   source:
     url: "https://example.com/meson-project-source.tar.gz"
     type: tar


### PR DESCRIPTION
Update the docs for the meson buildargs option.  Convert example to use list