### PR TITLE
Fix: update getting started to show vib plugin instructions

### DIFF
--- a/docs/articles/en/getting-started.md
+++ b/docs/articles/en/getting-started.md
@@ -27,7 +27,7 @@ Other container engines might work but have not been tested. If you have tested 
 
 ## Installation
 
-Vib is distributed as a single binary, so there's no need to install any runtime or dependencies. You can download the latest version of Vib from the [GitHub releases page](https://github.com/Vanilla-OS/Vib). Once downloaded, make the file executable and move it to a directory included in your PATH.
+Vib is distributed as a single binary, so there's no need to install any runtime or dependencies. You can download the latest version of Vib from the [GitHub releases page](https://github.com/Vanilla-OS/Vib). In addition to this, Vib has official plugins which are used for all the Vanilla-OS images, they can also be downlaoded from the [Github releases page](https://github.com/Vanilla-OS/Vib) as the `plugins.tar.xz` archvie. Once downloaded, make vib executable and move it to a directory included in your PATH. Vib searches for plugins in a global search path at `/usr/share/vib/plugins/` and inside the `plugins` directory in your project directory. It is recommended to extract `plugins.tar.xz` to `/usr/share/vib/plugins/` as they are considered core vib plugins and may be used by a lot of images.
 
 The following commands will allow you to download and install Vib:
 
@@ -40,9 +40,25 @@ mv vib ~/.local/bin
 If wget is not installed, you can use curl:
 
 ```bash
-curl -L https://github.com/Vanilla-OS/Vib/releases/latest/download/vib -o vib
+curl -SLO https://github.com/Vanilla-OS/Vib/releases/latest/download/vib
 chmod +x vib
 mv vib ~/.local/bin
+```
+
+The following commands for the plugins:
+
+```bash
+wget https://github.com/Vanilla-OS/Vib/releases/latest/download/plugins.tar.xz
+mkdir -p /usr/share/vib/plugins
+tar -xvf plugins.tar.xz -C /usr/share/vib/plugins/
+```
+
+Or with curl:
+
+```bash
+curl -SLO https://github.com/Vanilla-OS/Vib/releases/latest/download/plugins.tar.xz
+mkdir -p /usr/share/vib/plugins
+tar xvf plugins.tar.xz -C /usr/share/vib/plugins
 ```
 
 ## Usage


### PR DESCRIPTION
Updates the getting started document to reflect our changes with externally built plugins.