### PR TITLE
feat: [close #104] Stage sources per module

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -2,15 +2,14 @@ package api
 
 // Configuration for a source
 type Source struct {
-	URL         string   `json:"url"`
-	Checksum    string   `json:"checksum"`
-	Type        string   `json:"type"`
-	Destination string   `json:"destination"`
-	Commit      string   `json:"commit"`
-	Tag         string   `json:"tag"`
-	Branch      string   `json:"branch"`
-	Packages    []string `json:"packages"`
-	Paths       []string `json:"paths"`
+	URL      string   `json:"url"`
+	Checksum string   `json:"checksum"`
+	Type     string   `json:"type"`
+	Commit   string   `json:"commit"`
+	Tag      string   `json:"tag"`
+	Branch   string   `json:"branch"`
+	Packages []string `json:"packages"`
+	Path     string   `json:"path"`
 }
 
 // Configuration for a recipe

--- a/plugins/dpkg-buildpackage.go
+++ b/plugins/dpkg-buildpackage.go
@@ -4,7 +4,6 @@ import (
 	"C"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/vanilla-os/vib/api"
 )
@@ -58,12 +57,10 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 
 	cmd := fmt.Sprintf(
 		"cd /sources/%s && dpkg-buildpackage -d -us -uc -b",
-		filepath.Join(api.GetSourcePath(module.Source, module.Name)),
+		api.GetSourcePath(module.Source, module.Name),
 	)
 
-	for _, path := range module.Source.Paths {
-		cmd += fmt.Sprintf(" && apt install -y --allow-downgrades ../%s*.deb", path)
-	}
+	cmd += fmt.Sprintf(" && apt install -y --allow-downgrades ../%s*.deb", module.Source.Path)
 
 	cmd += " && apt clean"
 	return C.CString(cmd)


### PR DESCRIPTION
Instead of staging sources all at once, allow vib to stage sources per module and clean sources after the module by itself, this allows users to manage sources easier and also completely skip the sources step if no module defines any sources.

closes #104 