### PR TITLE
fix: exit with non zero returncode on error

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var rootCmd = &cobra.Command{
 	Use:     "vib",
 	Short:   "Vib is a tool to build container images from recipes using modules",
 	Long:    "Vib is a tool to build container images from YAML recipes using modules to define the steps to build the image.",
+	SilenceUsage: true,
 	Version: Version,
 }
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"github.com/vanilla-os/vib/cmd"
 )
 
@@ -9,5 +10,8 @@ var (
 )
 
 func main() {
-	cmd.Execute()
+	err := cmd.Execute()
+	if (err != nil) {
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
Exit with a nonzero return code when vib fails and dont print the usage output on error