### PR TITLE
Fix/proper includes handling

### DIFF
--- a/api/structs.go
+++ b/api/structs.go
@@ -21,6 +21,7 @@ type Recipe struct {
 	ParentPath    string
 	DownloadsPath string
 	SourcesPath   string
+	IncludesPath  string
 	PluginPath    string
 	Containerfile string
 	Finalize      []interface{}

--- a/core/build.go
+++ b/core/build.go
@@ -230,16 +230,10 @@ func BuildContainerfile(recipe *api.Recipe) error {
 		}
 
 		// INCLUDES.CONTAINER
-		_, err = containerfile.WriteString("ADD includes.container /\n")
+		_, err = containerfile.WriteString(fmt.Sprintf("ADD %s /\n", recipe.IncludesPath))
 		if err != nil {
 			return err
 		}
-
-		// SOURCES
-		/*_, err = containerfile.WriteString("ADD sources /sources\n")
-		if err != nil {
-			return err
-		}*/
 
 		for _, cmd := range cmds {
 			err = ChangeWorkingDirectory(cmd.Workdir, containerfile)

--- a/core/loader.go
+++ b/core/loader.go
@@ -97,10 +97,12 @@ func LoadRecipe(path string) (*api.Recipe, error) {
 	// directory. For example, if you want to include a file in
 	// /etc/nginx/nginx.conf you must place it in includes/etc/nginx/nginx.conf
 	// so it will be copied to the correct location in the container
-	includesContainerPath := filepath.Join(filepath.Dir(recipePath), "includes.container")
-	_, err = os.Stat(includesContainerPath)
+	if len(strings.TrimSpace(recipe.IncludesPath)) == 0 {
+		recipe.IncludesPath = filepath.Join("includes.container")
+	}
+	_, err = os.Stat(recipe.IncludesPath)
 	if os.IsNotExist(err) {
-		err := os.MkdirAll(includesContainerPath, 0755)
+		err := os.MkdirAll(recipe.IncludesPath, 0755)
 		if err != nil {
 			return nil, err
 		}

--- a/core/shell.go
+++ b/core/shell.go
@@ -28,7 +28,7 @@ func BuildShellModule(moduleInterface interface{}, recipe *api.Recipe) (string, 
 
 	for _, source := range module.Sources {
 		if strings.TrimSpace(source.Type) != "" {
-			err := api.DownloadSource(recipe.DownloadsPath, source, module.Name)
+			err := api.DownloadSource(recipe, source, module.Name)
 			if err != nil {
 				return "", err
 			}

--- a/plugins/cmake.go
+++ b/plugins/cmake.go
@@ -48,7 +48,7 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	err = api.DownloadSource(recipe.DownloadsPath, module.Source, module.Name)
+	err = api.DownloadSource(recipe, module.Source, module.Name)
 	if err != nil {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}

--- a/plugins/dpkg-buildpackage.go
+++ b/plugins/dpkg-buildpackage.go
@@ -46,7 +46,7 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	err = api.DownloadSource(recipe.DownloadsPath, module.Source, module.Name)
+	err = api.DownloadSource(recipe, module.Source, module.Name)
 	if err != nil {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}

--- a/plugins/go.go
+++ b/plugins/go.go
@@ -48,7 +48,7 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	err = api.DownloadSource(recipe.DownloadsPath, module.Source, module.Name)
+	err = api.DownloadSource(recipe, module.Source, module.Name)
 	if err != nil {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}

--- a/plugins/make.go
+++ b/plugins/make.go
@@ -50,7 +50,7 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	err = api.DownloadSource(recipe.DownloadsPath, module.Source, module.Name)
+	err = api.DownloadSource(recipe, module.Source, module.Name)
 	if err != nil {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}

--- a/plugins/meson.go
+++ b/plugins/meson.go
@@ -47,7 +47,7 @@ func BuildModule(moduleInterface *C.char, recipeInterface *C.char) *C.char {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}
 
-	err = api.DownloadSource(recipe.DownloadsPath, module.Source, module.Name)
+	err = api.DownloadSource(recipe, module.Source, module.Name)
 	if err != nil {
 		return C.CString(fmt.Sprintf("ERROR: %s", err.Error()))
 	}


### PR DESCRIPTION
Instead of processing includes modules during the recipe parsing, process them like any other module. This allows users to use the includes module as a nested module of a different module.