### PR TITLE
Fix/purego ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,7 @@ jobs:
     - name: Build vib
       run: |
         go get ./...
+        go get github.com/ebitengine/purego
         make build
 
     - name: Build plugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,7 @@ jobs:
       run: |
         ./set_new_version ${{ github.ref_name }}
         go get ./...
+        go get github.com/ebitengine/purego
         make build
 
     - name: Build plugins


### PR DESCRIPTION
The ci for #121 and #127 is failing because the `go get ./...` command doesn't download purego, make sure it's manually downloaded with an extra go get command