### PR TITLE
fix: Properly drop root privileges when run with sudo

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,23 +37,27 @@ func Execute() error {
 		IsRoot = true
 		gid, err := strconv.Atoi(os.Getenv("SUDO_GID"))
 		if err != nil {
-			return fmt.Errorf("failed to get user uid through SUDO_UID: %s", err.Error())
+			return fmt.Errorf("failed to get user gid through SUDO_GID: %s", err.Error())
 		}
 		OrigGID = gid // go moment??
+
 		uid, err := strconv.Atoi(os.Getenv("SUDO_UID"))
 		if err != nil {
-			return fmt.Errorf("failed to get user uid through SUDO_GID: %s", err.Error())
+			return fmt.Errorf("failed to get user uid through SUDO_UID: %s", err.Error())
 		}
 		OrigUID = uid
+
 		user := os.Getenv("SUDO_USER")
 		os.Setenv("HOME", filepath.Join("/home", user))
+
+		err = syscall.Setegid(OrigGID)
+		if err != nil {
+			fmt.Println("WARN: Failed to drop GID root privileges ", OrigGID)
+
+		}
 		err = syscall.Seteuid(OrigUID)
 		if err != nil {
-			fmt.Println("WARN: Failed to drop root privileges")
-		}
-		err = syscall.Setgid(OrigGID)
-		if err != nil {
-			fmt.Println("WARN: Failed to drop root privileges")
+			fmt.Println("WARN: Failed to drop UID root privileges ", OrigUID)
 		}
 	}
 	return rootCmd.Execute()

--- a/core/compile.go
+++ b/core/compile.go
@@ -17,8 +17,8 @@ func CompileRecipe(recipePath string, runtime string, isRoot bool, origGid int, 
 		return err
 	}
 
-	syscall.Seteuid(0)
 	syscall.Setegid(0)
+	syscall.Seteuid(0)
 	switch runtime {
 	case "docker":
 		err = compileDocker(recipe, origGid, origUid)
@@ -35,8 +35,8 @@ func CompileRecipe(recipePath string, runtime string, isRoot bool, origGid int, 
 	default:
 		return fmt.Errorf("no runtime specified and the prometheus library is not implemented yet")
 	}
-	syscall.Seteuid(origUid)
 	syscall.Setegid(origGid)
+	syscall.Seteuid(origUid)
 
 	for _, finalizeInterface := range recipe.Finalize {
 		var module Finalize

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/containerd/typeurl/v2 v2.2.0 // indirect
 	github.com/cyphar/filepath-securejoin v0.3.4 // indirect
 	github.com/docker/go-units v0.5.0 // indirect
+	github.com/ebitengine/purego v0.8.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-intervals v0.0.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/docker/go-units v0.5.0 h1:69rxXcBk27SvSaaxTtLh/8llcHD8vYHT7WSdRZ/jvr4=
 github.com/docker/go-units v0.5.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/ebitengine/purego v0.8.2 h1:jPPGWs2sZ1UgOSgD2bClL0MJIqu58nOmIcBuXr62z1I=
+github.com/ebitengine/purego v0.8.2/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=


### PR DESCRIPTION
Change the order in which UID and GID are changed to properly drop all root privileges, currently the GID fails meaning the effective user ends up being a regular user with the root group