### PR TITLE
fix: remove "*" from moving tar sources

### DIFF
--- a/api/download.go
+++ b/api/download.go
@@ -256,7 +256,7 @@ func MoveSource(downloadPath string, sourcesPath string, source Source, moduleNa
 		os.MkdirAll(filepath.Join(sourcesPath, GetSourcePath(source, moduleName)), 0o777)
 		cmd := exec.Command(
 			"tar",
-			"-xf", filepath.Join(downloadPath, GetSourcePath(source, moduleName), moduleName+".tar*"),
+			"-xf", filepath.Join(downloadPath, GetSourcePath(source, moduleName), moduleName+".tar"),
 			"-C", filepath.Join(sourcesPath, GetSourcePath(source, moduleName)),
 		)
 		err := cmd.Run()


### PR DESCRIPTION
Before:
```
[nisel@MiWiFi-R4A-srv core-image]$ ~/.local/bin/vib-amd64 build
Building recipe Planifolia Core
Building module [packages-modules] of type [includes]
Building module [abroot] of type [shell]
Downloading source: https://github.com/nisel11/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
Source is tar: https://github.com/nisel11/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
Moving source: abroot
Error: exit status 2
```
Now:
```
[nisel@MiWiFi-R4A-srv core-image]$ ~/dev/planifolia/Vib/build/vib-amd64 build
Building recipe Planifolia Core
Building module [packages-modules] of type [includes]
Building module [abroot] of type [shell]
Downloading source: https://github.com/nisel11/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
Source is tar: https://github.com/nisel11/ABRoot/releases/download/v2.2.0/abrootv2.tar.gz
Moving source: abroot
Module [abroot] built successfully
```